### PR TITLE
Get Messages from a Queue: Enabling Long Polling using the 'wait' parameter

### DIFF
--- a/IronMQ.class.php
+++ b/IronMQ.class.php
@@ -151,7 +151,8 @@ class IronMQ extends IronCore
     );
 
     const LIST_QUEUES_PER_PAGE = 30;
-    const GET_MESSAGE_TIMEOUT = 60;
+    const GET_MESSAGE_TIMEOUT  = 60;
+    const GET_MESSAGE_WAIT     = 0;  // Seconds to wait until request finds a Message (Max is 30)
 
     /**
      * @param string|array $config
@@ -314,9 +315,10 @@ class IronMQ extends IronCore
      * @param string $queue_name Queue name
      * @param int $count
      * @param int $timeout
+     * @param int $wait
      * @return array|null array of messages or null
      */
-    public function getMessages($queue_name, $count = 1, $timeout = self::GET_MESSAGE_TIMEOUT)
+    public function getMessages($queue_name, $count = 1, $timeout = self::GET_MESSAGE_TIMEOUT, $wait = self::GET_MESSAGE_WAIT)
     {
         $queue = rawurlencode($queue_name);
         $url = "projects/{$this->project_id}/queues/$queue/messages";
@@ -326,6 +328,9 @@ class IronMQ extends IronCore
         }
         if ($timeout !== self::GET_MESSAGE_TIMEOUT) {
             $params['timeout'] = (int) $timeout;
+        }
+        if ($wait !== 0) {
+            $params['wait'] = (int) $wait;
         }
         $this->setJsonHeaders();
         $response = $this->apiCall(self::GET, $url, $params);
@@ -342,11 +347,12 @@ class IronMQ extends IronCore
      *
      * @param string $queue_name Queue name
      * @param int $timeout
+     * @param int $wait
      * @return mixed|null single message or null
      */
-    public function getMessage($queue_name, $timeout = self::GET_MESSAGE_TIMEOUT)
+    public function getMessage($queue_name, $timeout = self::GET_MESSAGE_TIMEOUT, $wait = self::GET_MESSAGE_WAIT)
     {
-        $messages = $this->getMessages($queue_name, 1, $timeout);
+        $messages = $this->getMessages($queue_name, 1, $timeout, $wait);
         if ($messages) {
             return $messages[0];
         } else {

--- a/README.md
+++ b/README.md
@@ -275,14 +275,14 @@ Default is 604,800 seconds (7 days). Maximum is 2,592,000 seconds (30 days).
 
 ```php
 <?php
-$message = $ironmq->getMessage($queue_name, $timeout);
+$message = $ironmq->getMessage($queue_name, $timeout, $wait);
 ```
 
 **Multiple messages:**
 
 ```php
 <?php
-$message = $ironmq->getMessages($queue_name, $count, $timeout);
+$message = $ironmq->getMessages($queue_name, $count, $timeout, $wait);
 ```
 
 **Optional parameters:**
@@ -293,6 +293,9 @@ $message = $ironmq->getMessages($queue_name, $count, $timeout);
 You must delete the message from the queue to ensure it does not go back onto the queue.
 If not set, value from POST is used. Default is 60 seconds. Minimum is 30 seconds.
 Maximum is 86,400 seconds (24 hours).
+
+* `$wait`: Time in seconds to wait for a message to become available.
+This enables long polling. Default is 0 (does not wait), maximum is 30.
 
 --
 
@@ -405,8 +408,8 @@ $ironmq->deleteAlertById("test_alert_queue", $alert_id);
 
 ## Push Queues
 
-IronMQ push queues allow you to setup a queue that will push to an endpoint, rather than having to poll the endpoint. 
-[Here's the announcement for an overview](http://blog.iron.io/2013/01/ironmq-push-queues-reliable-message.html). 
+IronMQ push queues allow you to setup a queue that will push to an endpoint, rather than having to poll the endpoint.
+[Here's the announcement for an overview](http://blog.iron.io/2013/01/ironmq-push-queues-reliable-message.html).
 
 ### Update a Message Queue
 


### PR DESCRIPTION
This would allow both getMessage() and getMessages() to receive an integer `wait` parameter which will enable Long Polling on the Queue up to 30 seconds.
