### PR TITLE
Check if $this->use_keystone is set before using it

### DIFF
--- a/IronMQ.class.php
+++ b/IronMQ.class.php
@@ -800,7 +800,7 @@ class IronMQ extends IronCore
     private function setJsonHeaders()
     {
         $this->setCommonHeaders();
-        $token = $this->use_keystone ? $this->getToken(): $this->token;
+        $token = isset($this->use_keystone) && $this->use_keystone ? $this->getToken(): $this->token;
         $this->headers['Authorization'] ="OAuth {$token}";
     }
 


### PR DESCRIPTION
For those running in “strict” mode, `$this->use_keystone` needs to be set
or checked if `isset()` before trying to access it. Otherwise, an error is thrown.

`$this->use_keystone` was introduced by #38 .