### PR TITLE
V3 obsolete?

### DIFF
--- a/IronMQ.class.php
+++ b/IronMQ.class.php
@@ -145,9 +145,9 @@ class IronMQ extends IronCore
     protected $product_name   = 'iron_mq';
     protected $default_values = array(
         'protocol'    => 'https',
-        'host'        => 'mq-aws-us-east-1-1.iron.io',
+        'host'        => 'mq-aws-us-east-1.iron.io',
         'port'        => '443',
-        'api_version' => '3',
+        'api_version' => '1',
     );
 
     const LIST_QUEUES_PER_PAGE = 30;

--- a/IronMQ.class.php
+++ b/IronMQ.class.php
@@ -627,7 +627,7 @@ class IronMQ extends IronCore
         $this->setJsonHeaders();
         $queue = rawurlencode($queue_name);
         $url = "projects/{$this->project_id}/queues/$queue";
-        return self::json_decode($this->apiCall(self::PATCH, $url, array('queue' => $options)));
+        return self::json_decode($this->apiCall(self::POST, $url, array('queue' => $options)));
     }
 
     /**


### PR DESCRIPTION
is V3 outdated? I used it because the readme that this is the right version for laravel 4.2 with namespaces. Here are two fixes, probably there are more which are done in v1.